### PR TITLE
test: pass mise fixture config explicitly

### DIFF
--- a/tests/chezmoi/test-mise-direct-metadata.sh
+++ b/tests/chezmoi/test-mise-direct-metadata.sh
@@ -23,11 +23,9 @@ headless = true
 theme = "black-metal-bathory"
 TOML
 
-CHEZMOI_CONFIG_FILE="$TEST_ROOT/chezmoi.toml" \
-  chezmoi execute-template --source "$ROOT" \
+chezmoi --config "$TEST_ROOT/chezmoi.toml" execute-template --source "$ROOT" \
   <"$ROOT/dot_config/mise/config.toml.tmpl" >"$RENDERED_CONFIG"
-CHEZMOI_CONFIG_FILE="$TEST_ROOT/chezmoi.toml" \
-  chezmoi execute-template --source "$ROOT" \
+chezmoi --config "$TEST_ROOT/chezmoi.toml" execute-template --source "$ROOT" \
   <"$ROOT/.chezmoiscripts/run_after_install_tools.sh.tmpl" >"$RENDERED_SCRIPT"
 chmod +x "$RENDERED_SCRIPT"
 


### PR DESCRIPTION
## Summary
- pass the fixture config with the supported `--config` flag
- keep the test compatible with CI's Chezmoi 2.71.1

## Verification
- `bash tests/ci/check-static.sh`
- `bash tests/ci/run-chezmoi-tests.sh`
- template render and lint smoke test
- targeted test with Chezmoi 2.71.1