### PR TITLE
docs(agents): prefer Crabbox for tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Keep one clear test owner per contract. Avoid duplicate assertions, implementation snapshots, and low-value matrices.
 - When behavior is removed or absorbed by broader coverage, remove or merge its stale tests and fixtures in the same change.
 - After the final edit, run the targeted owning tests, then `bash tests/ci/check-static.sh` and `bash tests/ci/run-chezmoi-tests.sh`.
+- Run repository tests through Crabbox on personal machines or whenever the `crabbox` CLI is available. Inspect the repository and Crabbox configuration first, and do not expose secrets or start paid infrastructure without explicit approval.
 - For template changes, also reproduce the template smoke job:
   ```bash
   config_dir=$(mktemp -d)


### PR DESCRIPTION
## Summary
- direct agents to run repository tests through Crabbox on personal machines or whenever the CLI is available
- retain safeguards around repository config, secrets, and paid infrastructure

## Verification
- Crabbox run `run_e76cc08dbbdb`: static checks passed and repository suite passed with 39 tests, 0 failures
- `bash tests/ci/check-static.sh`