### PR TITLE
fix: scope machine-specific configuration by role

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -106,7 +106,7 @@
 # --- optional ssh/bitwarden manifest settings ---
 {{- $ssh_bw_manifest_item := "" -}}
 {{- $ssh_bw_agent_sock_env := "BITWARDEN_SSH_AUTH_SOCK" -}}
-{{- if and (or $personal $work) (not $ephemeral) -}}
+{{- if and $personal (not $ephemeral) -}}
 {{-   if and (hasKey . "ssh_bw_manifest_item") .ssh_bw_manifest_item -}}
 {{-     $ssh_bw_manifest_item = .ssh_bw_manifest_item -}}
 {{-   else if stdinIsATTY -}}
@@ -183,7 +183,7 @@
   bearer_token = {{ (index $bw_executor_work "api-key").value | quote }}
 {{- end }}
 
-{{- if and $work (lookPath "bw") }}
+{{- if and $personal $work (lookPath "bw") }}
 {{- $bw_work := bitwardenFields "item" "0b9286df-9ffc-4ab8-996e-b42d014e44d4" }}
 
 [data.bw_work]
@@ -209,7 +209,7 @@
   remote = {{ $private_agent_skills_remote | quote }}
   checkout = {{ $private_agent_skills_checkout | quote }}
 
-{{ if and (or $personal $work) (lookPath "bw") }}
+{{ if and $personal (lookPath "bw") }}
 [bitwarden]
   unlock = "auto"
 {{ end }}

--- a/home/.chezmoiremove.tmpl
+++ b/home/.chezmoiremove.tmpl
@@ -7,6 +7,7 @@ lazy-lock.json
 {{ end }}
 {{ if not .personal }}
 ~/.agents
+~/.pi
 {{ end }}
 {{ if ne .chezmoi.os "darwin" }}
 ~/Assets

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -24,7 +24,9 @@ fzf = "latest"
 rust = "latest"
 chezmoi = "latest"
 hunk = "latest"
+{{ if or .personal .homelab -}}
 infisical = "latest"
+{{ end -}}
 {{ if ne .chezmoi.os "windows" -}}
 tmux = "latest"
 {{ end -}}

--- a/tests/chezmoi/test-bitwarden-role-gating.sh
+++ b/tests/chezmoi/test-bitwarden-role-gating.sh
@@ -139,6 +139,7 @@ assert_bw_item_ids() {
 
 assert_zero_bw_calls "ephemeral,headless"
 assert_zero_bw_calls "homelab"
+assert_zero_bw_calls "work"
 
 assert_bw_item_ids "personal" \
   "acf48b07-70b7-43d0-9b2d-b42d0149b091" \
@@ -149,7 +150,14 @@ assert_bw_item_ids "personal" \
   "afa4395b-8044-46b1-86c9-b48d007e82ac" \
   "0c4c3b88-6ed3-49a0-9f59-b487007acf3e"
 
-assert_bw_item_ids "work" \
+assert_bw_item_ids "personal,work" \
+  "acf48b07-70b7-43d0-9b2d-b42d0149b091" \
+  "d256649b-8944-43a3-a016-abc1018ad825" \
+  "7acadcd9-f0cf-4fa5-bed2-b46a00743ba5" \
+  "040ae08a-b331-4d3b-abc6-b303002d2a94" \
+  "007b0e02-0af0-41e4-9779-b42d0156e6aa" \
+  "afa4395b-8044-46b1-86c9-b48d007e82ac" \
+  "0c4c3b88-6ed3-49a0-9f59-b487007acf3e" \
   "0b9286df-9ffc-4ab8-996e-b42d014e44d4"
 
 echo "bitwarden role gating ok"

--- a/tests/chezmoi/test-role-routing.sh
+++ b/tests/chezmoi/test-role-routing.sh
@@ -62,4 +62,41 @@ assert_has homelab "$windows_private_helper"
 assert_has homelab "$posix_private_apply"
 assert_has homelab "$windows_private_apply"
 
+render_scope_templates() {
+  local name=$1 data=$2
+  chezmoi execute-template --source "$repo_root" --override-data "$data" \
+    <"$source_root/.chezmoiexternal.toml.tmpl" >"$tmpdir/$name.external"
+  chezmoi execute-template --source "$repo_root" --override-data "$data" \
+    <"$source_root/.chezmoiremove.tmpl" >"$tmpdir/$name.remove"
+  chezmoi execute-template --source "$repo_root" --override-data "$data" \
+    <"$source_root/dot_config/mise/config.toml.tmpl" >"$tmpdir/$name.mise"
+}
+
+personal_data='{"personal":true,"work":false,"homelab":false,"ephemeral":false,"headless":false,"chezmoi":{"os":"linux","username":"test"}}'
+personal_work_data='{"personal":true,"work":true,"homelab":false,"ephemeral":false,"headless":false,"chezmoi":{"os":"linux","username":"test"}}'
+work_data='{"personal":false,"work":true,"homelab":false,"ephemeral":false,"headless":false,"chezmoi":{"os":"linux","username":"test"}}'
+homelab_data='{"personal":false,"work":false,"homelab":true,"ephemeral":false,"headless":true,"chezmoi":{"os":"linux","username":"test"}}'
+
+render_scope_templates personal "$personal_data"
+render_scope_templates personal-work "$personal_work_data"
+render_scope_templates work "$work_data"
+render_scope_templates homelab "$homelab_data"
+
+assert_file_has() { grep -Fq "$2" "$1"; }
+assert_file_lacks() { if grep -Fq "$2" "$1"; then return 1; fi; }
+pi_remove=$(printf '%s/%s' '~' '.pi')
+
+for scope in personal personal-work; do
+  assert_file_has "$tmpdir/$scope.external" '[".pi"]'
+  assert_file_lacks "$tmpdir/$scope.remove" "$pi_remove"
+  assert_file_has "$tmpdir/$scope.mise" 'infisical = "latest"'
+done
+
+assert_file_has "$tmpdir/work.remove" "$pi_remove"
+assert_file_has "$tmpdir/homelab.remove" "$pi_remove"
+assert_file_lacks "$tmpdir/work.external" '[".pi"]'
+assert_file_lacks "$tmpdir/homelab.external" '[".pi"]'
+assert_file_lacks "$tmpdir/work.mise" 'infisical = "latest"'
+assert_file_has "$tmpdir/homelab.mise" 'infisical = "latest"'
+
 echo 'role routing matrix ok'


### PR DESCRIPTION
## Summary

- restrict Pi externals and Bitwarden-backed SSH configuration to personal-scoped machines
- clean up stale Pi configuration on non-personal machines
- install Infisical through mise only on personal or homelab machines
- extend role-routing and Bitwarden gating coverage

## Verification

- `bash tests/ci/check-static.sh`
- `bash tests/ci/run-chezmoi-tests.sh` - 39 passed
- `bash tests/ci/render-and-lint.sh` with the CI smoke configuration
- `git diff --check`