### PR TITLE
feat(theme): wire missing Neovim colorschemes

### DIFF
--- a/home/.chezmoidata/themes.yml
+++ b/home/.chezmoidata/themes.yml
@@ -867,7 +867,7 @@ themes:
       starship: "flatland"
       tmux_ukiyo: "tokyonight/night"
       zed: "Tokyo Night"
-      nvim: "tokyonight-night"
+      nvim: "base24-flatland"
       nvim_background: "dark"
 
   japanesque:
@@ -899,7 +899,7 @@ themes:
       starship: "japanesque"
       tmux_ukiyo: "tokyonight/night"
       zed: "Tokyo Night"
-      nvim: "tokyonight-night"
+      nvim: "base24-japanesque"
       nvim_background: "dark"
 
   nvim-dark:
@@ -931,7 +931,7 @@ themes:
       starship: "nvim-dark"
       tmux_ukiyo: "tokyonight/night"
       zed: "Tokyo Night"
-      nvim: "default"
+      nvim: "github_dark"
       nvim_background: "dark"
 
   sleepy-hollow:
@@ -963,7 +963,7 @@ themes:
       starship: "sleepy-hollow"
       tmux_ukiyo: "tokyonight/night"
       zed: "Tokyo Night"
-      nvim: "tokyonight-night"
+      nvim: "base24-sleepy-hollow"
       nvim_background: "dark"
 
   twilight:
@@ -995,7 +995,7 @@ themes:
       starship: "twilight"
       tmux_ukiyo: "gruvbox/dark"
       zed: "Monokai Pro"
-      nvim: "monokai-pro"
+      nvim: "base24-twilight"
       nvim_background: "dark"
 
   wryan:
@@ -1027,5 +1027,5 @@ themes:
       starship: "wryan"
       tmux_ukiyo: "tokyonight/night"
       zed: "Tokyo Night"
-      nvim: "tokyonight-night"
+      nvim: "base24-wryan"
       nvim_background: "dark"

--- a/tests/chezmoi/test-theme-registry.sh
+++ b/tests/chezmoi/test-theme-registry.sh
@@ -69,6 +69,23 @@ for key, expected in expected_black_metal_nvim.items():
             f"{key}: expected Neovim colorscheme {expected!r}, got {actual!r}"
         )
 
+expected_exact_nvim = {
+    "fahrenheit": "fahrenheit",
+    "flatland": "base24-flatland",
+    "japanesque": "base24-japanesque",
+    "nvim-dark": "github_dark",
+    "nightfly": "nightfly",
+    "sleepy-hollow": "base24-sleepy-hollow",
+    "twilight": "base24-twilight",
+    "wryan": "base24-wryan",
+}
+for key, expected in expected_exact_nvim.items():
+    actual = themes[key]["apps"]["nvim"]
+    if actual != expected:
+        raise SystemExit(
+            f"{key}: expected Neovim colorscheme {expected!r}, got {actual!r}"
+        )
+
 root = Path(sys.argv[2]) if sys.argv[2] else None
 if root:
     if not root.is_dir():


### PR DESCRIPTION
## Summary
- wire Fahrenheit, Flatland, Japanesque, Sleepy Hollow, Twilight, and Wryan to their exact Neovim colorschemes
- use `github_dark` for `nvim-dark`
- add regression coverage for the exact Neovim mappings

## Dependency
- Requires brendanlees/astronvim-config#1 for the corresponding plugin registrations.

## Verification
- `bash tests/ci/check-static.sh`
- `bash tests/ci/run-chezmoi-tests.sh` (39 passed)
- `CHEZMOI_CONFIG_FILE=... bash tests/ci/render-and-lint.sh`
- `nvim --headless` loaded all requested colorschemes successfully