### PR TITLE
chore: remove Herdr Browser plugin

### DIFF
--- a/agents/pi/APPEND_SYSTEM.md
+++ b/agents/pi/APPEND_SYSTEM.md
@@ -1,4 +1,4 @@
 # pi agent instructions
 
 - Before modifying durable Pi configuration, read and follow `~/.pi/agent/docs/features/harness-config-workflow.md`
-- In Herdr, use Bash `agent-browser` through Herdr Browser for general browser work. Keep Chrome DevTools for diagnostics, performance, and network inspection, and Playwriter for authenticated or profile-aware interaction. Follow `browser-session-discipline` and keep one browser owner.
+- Use Bash `agent-browser` for general browser work, Chrome DevTools for diagnostics, performance, and network inspection, and Playwriter for authenticated or profile-aware interaction. Follow `browser-session-discipline` and keep one browser owner.

--- a/home/.chezmoidata/herdr.yml
+++ b/home/.chezmoidata/herdr.yml
@@ -17,9 +17,6 @@ herdr:
     - id: herdr-file-viewer
       source: smarzban/herdr-file-viewer
       ref: 96fcc0a2bdd2727ec88c38f8c8806f97b7ca0ea0
-    - id: official.browser
-      source: ogulcancelik/herdr-browser
-      ref: be6888b71cf4eb5939ee79a746bd1a1c22ade046
     - id: herdr-navigator
       source: thanhdat77/herdr-navigator
       ref: 03b803a00341d58382b6cda70a7cd618af5b8806

--- a/tests/chezmoi/test-herdr-plugins.sh
+++ b/tests/chezmoi/test-herdr-plugins.sh
@@ -29,6 +29,7 @@ chmod +x "$fakebin/herdr"
 
 cat >"$tmpdir/state/chezmoi/herdr-plugins.txt" <<'STATE'
 old-plugin|example/old-plugin|old-ref
+official.browser|ogulcancelik/herdr-browser|be6888b71cf4eb5939ee79a746bd1a1c22ade046
 third774.last-workspace|third774/herdr-last-workspace|8b55ebf15deaa52b49ff1c2500aab0c19c729420
 persiyanov.reviewr|persiyanov/herdr-reviewr|f1dd491e47ef55410eca7c73daebe3726f06bda0
 STATE
@@ -45,7 +46,6 @@ plus_ref='f32b0825f12543c1d03e54fb10d1741c40d66cdc'
 last_workspace_ref='8b55ebf15deaa52b49ff1c2500aab0c19c729420'
 worktrunk_ref='e9131c0b576fd68635194c758c9691dbfb778b61'
 file_viewer_ref='96fcc0a2bdd2727ec88c38f8c8806f97b7ca0ea0'
-browser_ref='be6888b71cf4eb5939ee79a746bd1a1c22ade046'
 navigator_ref='03b803a00341d58382b6cda70a7cd618af5b8806'
 crabbox_ref='70aaebd1083615eadeddb920b1f344822a2f013b'
 grep -Fxq "plugin install paulbkim-dev/vim-herdr-navigation --ref $nav_ref --yes" "$tmpdir/herdr.log"
@@ -53,10 +53,10 @@ grep -Fxq "plugin install cloudmanic/herdr-plus --ref $plus_ref --yes" "$tmpdir/
 grep -Fxq "plugin install third774/herdr-last-workspace --ref $last_workspace_ref --yes" "$tmpdir/herdr.log"
 grep -Fxq "plugin install devashish2203/herdr-worktrunk --ref $worktrunk_ref --yes" "$tmpdir/herdr.log"
 grep -Fxq "plugin install smarzban/herdr-file-viewer --ref $file_viewer_ref --yes" "$tmpdir/herdr.log"
-grep -Fxq "plugin install ogulcancelik/herdr-browser --ref $browser_ref --yes" "$tmpdir/herdr.log"
 grep -Fxq "plugin install thanhdat77/herdr-navigator --ref $navigator_ref --yes" "$tmpdir/herdr.log"
 grep -Fxq "plugin install openclaw/crabbox/plugins/herdr --ref $crabbox_ref --yes" "$tmpdir/herdr.log"
 grep -Fxq 'plugin uninstall old-plugin' "$tmpdir/herdr.log"
+grep -Fxq 'plugin uninstall official.browser' "$tmpdir/herdr.log"
 grep -Fxq 'plugin uninstall persiyanov.reviewr' "$tmpdir/herdr.log"
 grep -Fxq "vim-herdr-navigation|paulbkim-dev/vim-herdr-navigation|$nav_ref" \
   "$tmpdir/state/chezmoi/herdr-plugins.txt"
@@ -68,14 +68,12 @@ grep -Fxq "worktrunk|devashish2203/herdr-worktrunk|$worktrunk_ref" \
   "$tmpdir/state/chezmoi/herdr-plugins.txt"
 grep -Fxq "herdr-file-viewer|smarzban/herdr-file-viewer|$file_viewer_ref" \
   "$tmpdir/state/chezmoi/herdr-plugins.txt"
-grep -Fxq "official.browser|ogulcancelik/herdr-browser|$browser_ref" \
-  "$tmpdir/state/chezmoi/herdr-plugins.txt"
 grep -Fxq "herdr-navigator|thanhdat77/herdr-navigator|$navigator_ref" \
   "$tmpdir/state/chezmoi/herdr-plugins.txt"
 grep -Fxq "crabbox|openclaw/crabbox/plugins/herdr|$crabbox_ref" \
   "$tmpdir/state/chezmoi/herdr-plugins.txt"
 grep -Fxq 'open_mode = "workspace"' "$tmpdir/plugin-config/config.toml"
-for removed_plugin in old-plugin persiyanov.reviewr; do
+for removed_plugin in old-plugin official.browser persiyanov.reviewr; do
   if grep -Fq "$removed_plugin" "$tmpdir/state/chezmoi/herdr-plugins.txt"; then
     echo "stale managed plugin remained in state ledger: $removed_plugin" >&2
     exit 1


### PR DESCRIPTION
## Summary
- remove the Herdr Browser plugin from the desired plugin ledger
- uninstall stale `official.browser` entries during reconciliation
- route browser work through agent-browser, Chrome DevTools, and Playwriter instead
- keep Herdr terminal, layout, and agent tooling intact

## Verification
- `bash tests/chezmoi/test-herdr-plugins.sh`
  - passed
