### PR TITLE
fix(kanata): sync Vial layout and space hold

### DIFF
--- a/home/dot_config/kanata/README.md
+++ b/home/dot_config/kanata/README.md
@@ -15,9 +15,10 @@ used for re-mapping internal laptop keyboards.
 | `j`    | j   | ctrl  |
 | `k`    | k   | shift |
 | `l`    | l   | alt   |
-| `;`    | ;   | `lmet` (left Command) |
-| `caps` | esc | hyper |
+| `;`    | ;   | `rmet` (right Command) |
+| `caps` | esc | - |
 | `lmet` | bspc | left Command |
+| `/`    | /   | hyper |
 
 **positional disambiguation (timeless homerow mods).** the eight letter HRMs (a/s/d/f/j/k/l/`;`) use `tap-hold-release-keys` so:
 
@@ -27,21 +28,23 @@ used for re-mapping internal laptop keyboards.
 
 hand groupings live in `(defvar left-hand-keys ...)` / `right-hand-keys` and cover every alpha column in `defsrc` **except the eight HRM positions themselves** (`a`/`s`/`d`/`f`, `j`/`k`/`l`/`;`) — those are excluded so same-hand mod chords like `Alt+Shift+T` still work. see `docs/timeless-hrm.md` for the polarity gotcha and the chord-vs-roll trade-off.
 
-`caps` (esc/hyper) and `lmet` (bspc/left Command) remain plain timing-based tap-hold — not homerow letters, no roll concern.
+`caps` is plain Escape. `/` (slash/Hyper) and `lmet` (backspace/left Command) remain plain timing-based tap-hold — not homerow letters, no roll concern.
 
 tap-timeout: 300ms, hold-timeout: 200ms.
 
-### bottom-row tap-dance macros (tap/hold)
+### base-layer tap-dance macros (tap/hold)
 
-mirrors QMK tap-dance + macro setup on z/x/c/v/b. hold fires once via `(macro ...)` so the OS doesn't auto-repeat the command on long hold.
+mirrors the QMK tap-dance + macro setup on q/e/z/x/c/v. hold fires once via `(macro ...)` so the OS doesn't auto-repeat the command on long hold.
 
 | key | tap | hold               |
 | --- | --- | ------------------ |
+| `q` | q   | Cmd+Q (quit)       |
+| `e` | e   | Cmd+A (select all) |
 | `z` | z   | Cmd+Z (undo)       |
 | `x` | x   | Cmd+X (cut)        |
 | `c` | c   | Cmd+C (copy)       |
 | `v` | v   | Cmd+V (paste)      |
-| `b` | b   | Cmd+A (select all) |
+| `b` | b   | -                  |
 
 timeout matches homerow mods (300ms tap, 200ms hold).
 
@@ -69,7 +72,7 @@ timeout matches homerow mods (300ms tap, 200ms hold).
 
 ### space-hold layer (arrows)
 
-hold `space` to activate the arrows layer. synced from QMK Layer 1 (Iris split keyboard).
+hold `space` to activate the arrows layer. synced from QMK Layer 1 (Iris split keyboard). The dual-role uses a deferred 200ms tap-hold, matching QMK `LT1(KC_SPACE)`.
 
 **number row — screenshot shortcuts:**
 
@@ -101,7 +104,7 @@ mirrors `SGUI(KC_2)` / `SGUI(KC_3)` from QMK Layer 1 (macOS screenshot-style sho
 | key  | output         |
 | ---- | -------------- |
 | caps | tab            |
-| a    | OSM(Shift+Cmd) |
+| a    | transparent    |
 | s    | `(`            |
 | d    | `)`            |
 | f    | `{`            |
@@ -118,12 +121,12 @@ mirrors `SGUI(KC_2)` / `SGUI(KC_3)` from QMK Layer 1 (macOS screenshot-style sho
 | key  | output      |
 | ---- | ----------- |
 | lsft | Shift+Tab   |
-| z    | LCtrl       |
+| z    | transparent |
 | x    | Cmd+Shift+C |
-| c    | keypad dot      |
+| c    | transparent  |
 | v    | `[`         |
 | b    | `]`         |
-| n    | `\`         |
+| n    | keypad `/`  |
 | m    | `\|`        |
 | ,    | `-`         |
 | .    | `+`         |

--- a/home/dot_config/kanata/config.kbd
+++ b/home/dot_config/kanata/config.kbd
@@ -70,8 +70,8 @@
 
 ;; define aliases for homerow mods
 (defalias
-  ;; caps lock: tap for escape, hold for Hyper
-  esc (tap-hold $tap-timeout 200 esc (multi lctl lalt lsft lmet))
+  ;; caps lock: tap for Escape; QMK layer 6 is reserved/transparent
+  caps_esc esc
 
   ;; left homerow mods — timeless positional: same-hand roll forces tap,
   ;; opposite-hand press+release commits hold instantly.
@@ -84,24 +84,26 @@
   j_ctl    (tap-hold-release-keys $tap-timeout $hold-timeout j rctl $right-hand-keys)  ;; j: tap for 'j', hold for Control
   k_sft    (tap-hold-release-keys $tap-timeout $hold-timeout k rsft $right-hand-keys)  ;; k: tap for 'k', hold for Shift
   l_alt    (tap-hold-release-keys $tap-timeout $hold-timeout l lalt $right-hand-keys)  ;; l: tap for 'l', hold for Alt
-  scln_cmd (tap-hold-release-keys $tap-timeout $hold-timeout ; lmet $right-hand-keys)  ;; ;: tap for ';', hold for left Command (Meta)
+  scln_cmd (tap-hold-release-keys $tap-timeout $hold-timeout ; rmet $right-hand-keys)  ;; ;: tap for ';', hold for right Command (Meta)
 
-  ;; one-shot Shift+Cmd (mirrors QMK OSM(MOD_LSFT|MOD_LGUI) on 'a' in arrows layer)
-  osm_sg (multi (one-shot 2000 lsft) (one-shot 2000 lmet))
+  ;; slash: tap for slash, hold for Hyper (mirrors QMK ALL_T(KC_SLASH))
+  slash_hyp (tap-hold $tap-timeout 200 / (multi lctl lalt lsft lmet))
 
   ;; left cmd: tap for backspace, hold for Command (mirrors QMK LGUI_T(KC_BSPACE) on Iris thumb)
   cmd_bspc (tap-hold-press $tap-timeout $hold-timeout bspc lmet)
 
-  ;; space: tap for space, hold to activate arrows layer (vim hjkl navigation)
-  spc_arr (tap-hold-press $tap-timeout $hold-timeout spc (layer-while-held arrows))
+  ;; space: tap for space, hold to activate arrows layer (mirrors QMK LT1(KC_SPACE))
+  ;; use QMK's 200ms TAPPING_TERM and defer hold decisions until timeout/release
+  spc_arr (tap-hold 200 200 spc (layer-while-held arrows))
 
-  ;; bottom-row tap-dance macros (mirrors QMK TD(10-14) -> M0-M4 on z/x/c/v/b)
+  ;; base-layer tap-dance macros (mirrors QMK TD(10-15) -> M0-M5)
   ;; tap = letter, hold past 200ms = Cmd+letter (fires once via macro, no auto-repeat)
+  q_quit  (tap-hold $tap-timeout $hold-timeout q (macro M-q))  ;; q: tap q, hold = quit
+  e_all   (tap-hold $tap-timeout $hold-timeout e (macro M-a))  ;; e: tap e, hold = select-all
   z_undo  (tap-hold $tap-timeout $hold-timeout z (macro M-z))  ;; z: tap z, hold = undo
   x_cut   (tap-hold $tap-timeout $hold-timeout x (macro M-x))  ;; x: tap x, hold = cut
   c_copy  (tap-hold $tap-timeout $hold-timeout c (macro M-c))  ;; c: tap c, hold = copy
   v_paste (tap-hold $tap-timeout $hold-timeout v (macro M-v))  ;; v: tap v, hold = paste
-  b_all   (tap-hold $tap-timeout $hold-timeout b (macro M-a))  ;; b: tap b, hold = select-all
 )
 
 ;; base layer with homerow mods active
@@ -109,11 +111,11 @@
   ;; number row
   _ _
   ;; qwerty row
-  tab q w e _ _    _ _ _ _ _
+  tab @q_quit w @e_all _ _    _ _ _ _ _
   ;; home row
-  @esc @a_cmd @s_alt @d_sft @f_ctl _    h @j_ctl @k_sft @l_alt @scln_cmd _
-  ;; bottom row — z/x/c/v/b tap-dance macros (tap=letter, hold=Cmd+letter, once)
-  lsft @z_undo @x_cut @c_copy @v_paste @b_all    _ _ _ _ _ rsft
+  @caps_esc @a_cmd @s_alt @d_sft @f_ctl _    h @j_ctl @k_sft @l_alt @scln_cmd _
+  ;; bottom row — z/x/c/v tap-dance macros; b is plain
+  lsft @z_undo @x_cut @c_copy @v_paste b    _ _ _ _ @slash_hyp rsft
   ;; thumb
   @cmd_bspc @spc_arr
   ;; function / media keys
@@ -127,10 +129,10 @@
   M-S-2 M-S-3
   ;; qwerty row — shifted symbols: ~ ! @ # $ %    ^ & * ( )
   S-grv S-1 S-2 S-3 S-4 S-5    S-6 S-7 S-8 S-9 S-0
-  ;; home row — tab, OSM(S+G), parens, braces    arrows, transparent, pgup
-  tab @osm_sg S-9 S-0 S-lbrc S-rbrc    left down up rght _ pgup
-  ;; bottom row — S-tab, ctrl, sgui combos, brackets    backslash, pipe, math, pgdn
-  S-tab lctl M-S-c kp. lbrc rbrc    \ S-\ min S-eql eql pgdn
+  ;; home row — tab, transparent, parens, braces    arrows, transparent, pgup
+  tab _ S-9 S-0 S-lbrc S-rbrc    left down up rght _ pgup
+  ;; bottom row — S-tab, transparent, sgui combo, transparent, brackets    keypad slash, pipe, math, pgdn
+  S-tab _ M-S-c _ lbrc rbrc    kp/ S-\ min S-eql eql pgdn
   ;; thumb
   _ _
   ;; function / media keys


### PR DESCRIPTION
## Summary

- sync the selected Vial base and Layer 1 mappings, including the moved Hyper key
- match QMK `LT1(KC_SPACE)` with deferred 200ms tap-hold behavior
- update the Kanata README

## Validation

- `kanata --check -c home/dot_config/kanata/config.kbd`
- `python3 /Users/brendan/Code/iris-lm-config/tools/check_vil_keymap_sync.py`
- `git diff --check`