### PR TITLE
feat(atuin): inherit chezmoi theme palette

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,6 +1,6 @@
 # themes
 
-a single `theme` key in `home/.chezmoidata/defaults.yml` drives colors across ghostty, pi, herdr, tmux, nvim, btop, bat, starship, glow, zed and sketchybar.
+a single `theme` key in `home/.chezmoidata/defaults.yml` drives colors across ghostty, pi, herdr, tmux, nvim, btop, bat, starship, glow, zed, atuin and sketchybar.
 
 ## switching
 
@@ -28,6 +28,10 @@ pi uses a chezmoi-generated theme named `chezmoi` at `~/.pi/agent/themes/chezmoi
 
 herdr uses a chezmoi-generated config at `~/.config/herdr/config.toml`. The template maps the active semantic palette directly onto herdr's custom theme tokens, with the host terminal theme as the fallback.
 
+### atuin
+
+Atuin selects the generated `chezmoi` theme at `~/.config/atuin/themes/chezmoi.toml`. The template maps the active shared palette to Atuin's semantic colors and inherits any future meanings from Atuin's built-in `autumn` theme.
+
 ## file overview
 
 | file                                                                          | role                                                                                    |
@@ -36,6 +40,7 @@ herdr uses a chezmoi-generated config at `~/.config/herdr/config.toml`. The temp
 | `home/.chezmoidata/local.yml`                                                 | gitignored, host-local override - `theme` writes here                                   |
 | `home/.chezmoidata/themes.yml`                                                | registry: palette + per-app theme names                                                 |
 | `home/.chezmoitemplates/pi-theme.json.tmpl`                                   | shared source for the generated pi theme                                                |
+| `home/dot_config/atuin/themes/chezmoi.toml.tmpl`                              | generated Atuin theme using the active shared palette                                   |
 | `home/dot_config/herdr/config.toml.tmpl`                                      | tmux-compatible herdr keys and generated custom palette                                 |
 | `home/.chezmoiscripts/run_onchange_after_configure-pi-theme.py.tmpl`          | posix atomic writer for `~/.pi/agent/themes/chezmoi.json` after the `.pi` external sync |
 | `home/.chezmoiscripts/windows/run_onchange_after_configure-pi-theme.ps1.tmpl` | windows atomic writer for the same generated runtime theme                              |

--- a/home/dot_config/atuin/private_config.toml
+++ b/home/dot_config/atuin/private_config.toml
@@ -311,17 +311,17 @@ autostart = true
 ## starts once.
 # enabled = false
 
-# [theme]
+[theme]
 ## Color theme to use for rendering in the terminal.
 ## There are some built-in themes, including the base theme ("default"),
 ## "autumn" and "marine". You can add your own themes to the "./themes" subdirectory of your
-## Atuin config (or ATUIN_THEME_DIR, if provided) as TOML files whose keys should be one or
-## more of AlertInfo, AlertWarn, AlertError, Annotation, Base, Guidance, Important, and
-## the string values as lowercase entries from this list:
+## Atuin config (or ATUIN_THEME_DIR, if provided) as TOML files. Color values can be lowercase
+## entries from this list or six-character hex codes:
 ##    https://ogeon.github.io/docs/palette/master/palette/named/index.html
-## If you provide a custom theme file, it should be  called "NAME.toml" and the theme below
+## If you provide a custom theme file, it should be called "NAME.toml" and the theme below
 ## should be the stem, i.e. `theme = "NAME"` for your chosen NAME.
-name = "autumn"
+## The custom theme is generated from the active chezmoi palette.
+name = "chezmoi"
 
 ## Whether the theme manager should output normal or extra information to help fix themes.
 ## Boolean, true or false. If unset, left up to the theme manager.

--- a/home/dot_config/atuin/themes/chezmoi.toml.tmpl
+++ b/home/dot_config/atuin/themes/chezmoi.toml.tmpl
@@ -1,0 +1,25 @@
+# Theme generated from .chezmoidata/themes.yml
+# Active theme: {{ .theme }}
+# Atuin inherits any future meanings from its autumn theme.
+{{- $p := (index .themes .theme).palette }}
+
+[theme]
+name = "chezmoi"
+parent = "autumn"
+
+[colors]
+Base = "{{ $p.fg }}"
+AlertInfo = "{{ $p.info }}"
+AlertWarn = "{{ $p.warn }}"
+AlertError = "{{ $p.error }}"
+Annotation = "{{ $p.comment }}"
+Guidance = "{{ $p.accent }}"
+Important = "{{ $p.primary }}"
+Title = "{{ $p.primary_alt }}"
+Muted = "{{ $p.muted }}"
+SyntaxCommand = "{{ $p.primary }}"
+SyntaxFlag = "{{ $p.secondary }}"
+SyntaxString = "{{ $p.success }}"
+SyntaxVariable = "{{ $p.info_alt }}"
+SyntaxOperator = "{{ $p.fg }}"
+SyntaxComment = "{{ $p.comment }}"

--- a/tests/chezmoi/test-atuin-shell-integration.sh
+++ b/tests/chezmoi/test-atuin-shell-integration.sh
@@ -6,7 +6,50 @@ source_root="$repo_root/home"
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
-data='{"personal":true,"work":false,"homelab":false,"headless":false,"ephemeral":false,"chezmoi":{"os":"darwin","username":"test"}}'
+data='{"personal":true,"work":false,"homelab":false,"headless":false,"ephemeral":false,"theme":"guts","chezmoi":{"os":"darwin","username":"test"}}'
+
+atuin_theme_template="$source_root/dot_config/atuin/themes/chezmoi.toml.tmpl"
+chezmoi execute-template --source "$repo_root" --override-data "$data" \
+  --file "$atuin_theme_template" >"$tmpdir/atuin-theme.toml"
+chezmoi data --source "$repo_root" --format json >"$tmpdir/data.json"
+python3 - "$tmpdir/atuin-theme.toml" "$tmpdir/data.json" \
+  "$source_root/dot_config/atuin/private_config.toml" <<'PY'
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+theme = tomllib.loads(Path(sys.argv[1]).read_text())
+data = json.loads(Path(sys.argv[2]).read_text())
+config = tomllib.loads(Path(sys.argv[3]).read_text())
+palette = data["themes"]["guts"]["palette"]
+expected_mapping = {
+    "Base": "fg",
+    "AlertInfo": "info",
+    "AlertWarn": "warn",
+    "AlertError": "error",
+    "Annotation": "comment",
+    "Guidance": "accent",
+    "Important": "primary",
+    "Title": "primary_alt",
+    "Muted": "muted",
+    "SyntaxCommand": "primary",
+    "SyntaxFlag": "secondary",
+    "SyntaxString": "success",
+    "SyntaxVariable": "info_alt",
+    "SyntaxOperator": "fg",
+    "SyntaxComment": "comment",
+}
+if theme["theme"] != {"name": "chezmoi", "parent": "autumn"}:
+    raise SystemExit(f"unexpected Atuin theme inheritance: {theme['theme']!r}")
+expected_colors = {key: palette[value] for key, value in expected_mapping.items()}
+if theme.get("colors") != expected_colors:
+    raise SystemExit(f"Atuin palette mapping mismatch: {theme.get('colors')!r}")
+if config.get("theme") != {"name": "chezmoi"}:
+    raise SystemExit(f"Atuin config does not select chezmoi theme: {config.get('theme')!r}")
+if "name" in config.get("daemon", {}):
+    raise SystemExit("Atuin theme name must not be nested under daemon")
+PY
 
 chezmoi execute-template --source "$repo_root" --override-data "$data" \
   <"$source_root/dot_config/mise/config.toml.tmpl" >"$tmpdir/mise.toml"


### PR DESCRIPTION
## Summary
- generate Atuin's `chezmoi` theme from the active chezmoi palette
- inherit fallback meanings from Atuin's built-in `autumn` theme
- fix Atuin config to select the generated theme and add regression coverage

## Tests
- `bash tests/chezmoi/test-atuin-shell-integration.sh`
- `bash tests/ci/check-static.sh`
- `bash tests/ci/run-chezmoi-tests.sh` (39 passed)
- template render and lint smoke test